### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ MRI Tools
 .. image:: https://travis-ci.org/robbert-harms/mri-tools.svg?branch=master
         :target: https://travis-ci.org/robbert-harms/mri-tools
 
-.. image:: https://pypip.in/v/mri-tools/badge.png
+.. image:: https://img.shields.io/pypi/v/mri-tools.svg
         :target: https://pypi.python.org/pypi/mri-tools
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20mri-tools))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `mri-tools`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.